### PR TITLE
Add AI/ML API documentation

### DIFF
--- a/components/repeated/AdditionalLinks.mdx
+++ b/components/repeated/AdditionalLinks.mdx
@@ -7,7 +7,7 @@ Explore more about LibreChat and how to configure it to your needs.
 - **[Configuring AI Providers](/docs/configuration/pre_configured_ai)**
       - Configure OpenAI, Google, Anthropic, and OpenAI Assistants
 - **[Configuring a Custom Endpoint](./custom_endpoints)**
-      - Configure services such as Deepseek, OpenRouter, Ollama, Mistral AI, Databricks, groq, and others.
+      - Configure services such as Deepseek, OpenRouter, AI/ML API, Ollama, Mistral AI, Databricks, groq, and others.
       - **[Click here](/docs/configuration/librechat_yaml/ai_endpoints)** for a list of known, compatible services.
 - **[Environment Configuration](/docs/configuration/dotenv)**
       - Read for a comprehensive look at the `.env` file.

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/aimlapi.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/aimlapi.mdx
@@ -1,0 +1,31 @@
+---
+title: AI/ML API
+description: Example configuration for AI/ML API
+---
+
+# [AI/ML API](https://aimlapi.com/app/?utm_source=LibreChat&utm_medium=github&utm_campaign=integration)
+
+> AI/ML API provides **300+** models, including Deepseek, Gemini, and ChatGPT, all running with enterprise‑grade rate limits and uptimes.
+
+You can review the official documentation at [docs.aimlapi.com](https://docs.aimlapi.com/?utm_source=LibreChat&utm_medium=github&utm_campaign=integration).
+
+**Notes:**
+
+- **Known:** icon provided. Fetching the list of models is recommended to keep the dropdown up to date.
+
+```yaml filename="librechat.yaml"
+- name: 'AI/ML API'
+  apiKey: '${AI_ML_API_KEY}'
+  modelDisplayLabel: 'AI/ML API'
+  baseURL: 'https://api.aimlapi.com/v1'
+  iconURL: 'https://raw.githubusercontent.com/OctavianTheI/aimlapi-assets-devrel/main/aimlapi%20square%20Logo%20Icon.svg'
+  headers:
+    X-Title: 'LibreChat'
+  models:
+    default: ['gpt-4o']
+    fetch: true
+  titleConvo: true
+  titleModel: 'gpt-4o'
+```
+
+![image](https://github.com/user-attachments/assets/a829efa7-8944-42f1-8cd9-07024269ef5e)

--- a/pages/docs/configuration/librechat_yaml/example.mdx
+++ b/pages/docs/configuration/librechat_yaml/example.mdx
@@ -128,6 +128,20 @@ endpoints:
           "mistral-large-latest"
           ]
         fetch: true
+    # AI/ML API
+    - name: "AI/ML API"
+      apiKey: "${AI_ML_API_KEY}"
+      modelDisplayLabel: "AI/ML API"
+      baseURL: "https://api.aimlapi.com/v1"
+      iconURL: "https://raw.githubusercontent.com/OctavianTheI/aimlapi-assets-devrel/main/aimlapi%20square%20Logo%20Icon.svg"
+      headers:
+        X-Title: "LibreChat"
+      models:
+        default: ["gpt-4o"]
+        fetch: true
+      titleConvo: true
+      titleModel: "gpt-4o"
+
       titleConvo: true
       titleModel: "mistral-tiny"
       modelDisplayLabel: "Mistral"
@@ -384,6 +398,19 @@ endpoints:
       # Drop Default params parameters from the request. See default params in guide linked below.
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
       dropParams: ['stop', 'user', 'frequency_penalty', 'presence_penalty']
+    # AI/ML API Example
+    - name: 'AI/ML API'
+      apiKey: '${AI_ML_API_KEY}'
+      modelDisplayLabel: 'AI/ML API'
+      baseURL: 'https://api.aimlapi.com/v1'
+      iconURL: 'https://raw.githubusercontent.com/OctavianTheI/aimlapi-assets-devrel/main/aimlapi%20square%20Logo%20Icon.svg'
+      headers:
+        X-Title: 'LibreChat'
+      models:
+        default: ['gpt-4o']
+        fetch: true
+      titleConvo: true
+      titleModel: 'gpt-4o'
 
     # OpenRouter Example
     - name: 'OpenRouter'

--- a/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -122,6 +122,7 @@ iconURL: https://github.com/danny-avila/LibreChat/raw/main/docs/assets/LibreChat
   - "ollama"
   - "xai"
   - "MLX"
+  - "AI/ML API"
 
 ## models
 

--- a/pages/docs/configuration/librechat_yaml/setup.mdx
+++ b/pages/docs/configuration/librechat_yaml/setup.mdx
@@ -4,7 +4,7 @@
 
 You can copy the [example config file](/docs/configuration/librechat_yaml/example) as a good starting point while reading the rest of the guide.
 
-The example config file has some options ready to go for Mistral AI, Groq and Openrouter.
+The example config file has some options ready to go for Mistral AI, Groq, Openrouter, and AI/ML API.
 
 **Note:** You can set an alternate filepath for the `librechat.yaml` file through an environment variable:
 

--- a/pages/docs/configuration/pre_configured_ai/index.mdx
+++ b/pages/docs/configuration/pre_configured_ai/index.mdx
@@ -28,6 +28,6 @@ The following guides are available to help you configure different endpoints:
 
 The **[librechat.yaml Configuration Guides](/docs/configuration/librechat_yaml)** provides detailed instructions on how to configure custom endpoints within LibreChat.
 
-In addition to the pre-configured endpoints, the librechat config file allows you to add and configure custom endpoints. This includes integrating with AI providers like Ollama, Mistral AI, Openrouter, and a multitude of other third-party services.
+In addition to the pre-configured endpoints, the librechat config file allows you to add and configure custom endpoints. This includes integrating with AI providers like AI/ML API, Ollama, Mistral AI, Openrouter, and a multitude of other third-party services.
 
 By following these configuration guides, you can seamlessly integrate various AI providers, unlock their capabilities, and enhance your LibreChat experience with the power of multiple AI models and services.

--- a/pages/docs/features/index.mdx
+++ b/pages/docs/features/index.mdx
@@ -92,6 +92,7 @@ import Image from 'next/image'
 - **Apple MLX**: Apple's framework for machine learning and AI integration.
 - **koboldcpp**: AI-assisted storytelling and content generation tools.
 - **OpenRouter**: API gateway for routing AI model requests.
+- **AI/ML API**: Access 300+ models with enterprise-grade rate limits.
 - **together.ai**: Collaborative platform for AI model development and deployment.
 - **Perplexity**: AI-driven search engine for contextual answers.
 - **ShuttleAI**: Automated machine learning platform for rapid deployment.

--- a/pages/docs/quick_start/custom_endpoints.mdx
+++ b/pages/docs/quick_start/custom_endpoints.mdx
@@ -36,39 +36,46 @@ services:
 - **Add your custom endpoints:** you can view compatible endpoints in the [AI Endpoints section](/docs/configuration/librechat_yaml/ai_endpoints).
   - The list is not exhaustive and generally every OpenAI API-compatible service should work.
   - There are many options for Custom Endpoints. View them all here: [Custom Endpoint Object Structure](/docs/configuration/librechat_yaml/object_structure/custom_endpoint).
-- As an example, here is a configuration for both **OpenRouter** and **Ollama**:
+- As an example, here is a configuration for **AI/ML API**, **OpenRouter**, and **Ollama**:
 
-   ```yaml
-   version: 1.1.4
-   cache: true
-   endpoints:
-     custom:
-       - name: "OpenRouter"
-         apiKey: "${OPENROUTER_KEY}"
-         baseURL: "https://openrouter.ai/api/v1"
-         models:
-           default: ["gpt-3.5-turbo"]
-           fetch: true
-         titleConvo: true
-         titleModel: "current_model"
-         summarize: false
-         summaryModel: "current_model"
-         forcePrompt: false
-         modelDisplayLabel: "OpenRouter"
-       - name: "Ollama"
-         apiKey: "ollama"
-         baseURL: "http://host.docker.internal:11434/v1/"
-         models:
-           default: [
-             "llama3:latest",
-             "command-r",
-             "mixtral",
-             "phi3"
-             ]
-           fetch: true # fetching list of models is not supported
-         titleConvo: true
-         titleModel: "current_model"
-   ```
+  ```yaml
+  version: 1.1.4
+  cache: true
+  endpoints:
+    custom:
+      - name: 'AI/ML API'
+        apiKey: '${AI_ML_API_KEY}'
+        modelDisplayLabel: 'AI/ML API'
+        baseURL: 'https://api.aimlapi.com/v1'
+        iconURL: 'https://raw.githubusercontent.com/OctavianTheI/aimlapi-assets-devrel/main/aimlapi%20square%20Logo%20Icon.svg'
+        headers:
+          X-Title: 'LibreChat'
+        models:
+          default: ['gpt-4o']
+          fetch: true
+        titleConvo: true
+        titleModel: 'gpt-4o'
+      - name: 'OpenRouter'
+        apiKey: '${OPENROUTER_KEY}'
+        baseURL: 'https://openrouter.ai/api/v1'
+        models:
+          default: ['gpt-3.5-turbo']
+          fetch: true
+        titleConvo: true
+        titleModel: 'current_model'
+        summarize: false
+        summaryModel: 'current_model'
+        forcePrompt: false
+        modelDisplayLabel: 'OpenRouter'
+      - name: 'Ollama'
+        apiKey: 'ollama'
+        baseURL: 'http://host.docker.internal:11434/v1/'
+        models:
+          default: ['llama3:latest', 'command-r', 'mixtral', 'phi3']
+          fetch: true # fetching list of models is not supported
+        titleConvo: true
+        titleModel: 'current_model'
+  ```
 
 <Callout type="warning" title="Important: API Key Configuration">
 When configuring API keys in custom endpoints, you have two options:
@@ -89,15 +96,17 @@ When configuring API keys in custom endpoints, you have two options:
    ```
 
 This is different from pre-configured endpoints in the .env file where you would set `ENDPOINT_KEY=user_provided` (e.g., `OPENAI_API_KEY=user_provided`).
+
 </Callout>
 
 ## Step 3. Configure .env File
 
-- **Edit your existing `.env` file** at the project root 
-    - Copy `.env.example` and rename to `.env` if it doesn't already exist.
-- According to the config above, the environment variable `OPENROUTER_KEY` is expected and should be set:
+- **Edit your existing `.env` file** at the project root
+  - Copy `.env.example` and rename to `.env` if it doesn't already exist.
+- According to the config above, the environment variables `AI_ML_API_KEY` and `OPENROUTER_KEY` are expected and should be set:
 
 ```bash
+AI_ML_API_KEY=your_aimlapi_api_key
 OPENROUTER_KEY=your_openrouter_api_key
 ```
 

--- a/pages/docs/quick_start/index.mdx
+++ b/pages/docs/quick_start/index.mdx
@@ -8,4 +8,4 @@ Use this easy setup guide and start using LibreChat as quickly as possible.
 
 #### [Custom Endpoints](./quick_start/custom_endpoints)
 
-Configure custom endpoints for services like OpenRouter, Deepseek, Ollama, Mistral AI, groq, Databricks, and others.
+Configure custom endpoints for services like AI/ML API, OpenRouter, Deepseek, Ollama, Mistral AI, groq, Databricks, and others.

--- a/pages/docs/user_guides/ai_overview.mdx
+++ b/pages/docs/user_guides/ai_overview.mdx
@@ -27,4 +27,4 @@ LibreChat allows you to configure and integrate various AI providers, APIs, and 
 
 4. **Set Default Endpoint and Preset**: Specify a default endpoint and preset to streamline the process of starting new conversations. Here's a video to demonstrate: **[Setting a Default Preset](https://github.com/danny-avila/LibreChat/assets/110412045/bbde830f-18d9-4884-88e5-1bd8f7ac585d)**
 
-5. **Customize Configurations**: Explore advanced configuration options, such as adding custom endpoints like Ollama, Mistral AI or Openrouter.
+5. **Customize Configurations**: Explore advanced configuration options, such as adding custom endpoints like Ollama, Mistral AI, Openrouter, or AI/ML API.


### PR DESCRIPTION
## Summary
- document new AI/ML API provider with full config example
- show how to configure it in `librechat.yaml`
- update custom endpoint quick-start and example references
- restore example config quoting

## Testing
- `npx prettier -w pages/docs/configuration/librechat_yaml/example.mdx`
- `pnpm lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b74ea9c8329b512e929f2c56fb2